### PR TITLE
Tooltip for encumbrance

### DIFF
--- a/src/templates/party.hbs
+++ b/src/templates/party.hbs
@@ -94,8 +94,8 @@
           </div>
 
           {{#with system.stats.secondaryAttributes.encumbrance}}
-          <div class="party-meter party-meter--encumbrance" aria-label="{{localize 'ZWEI.actor.secondary.encumbrance'}}"
-            data-toolip="{{localize 'ZWEI.actor.secondary.encumbrance'}}">
+          <div class="party-meter party-meter--encumbrance" aria-label="{{localize 'ZWEI.actor.secondary.encumbranceLimit'}}"
+            data-toolip="{{localize 'ZWEI.actor.secondary.encumbranceLimit'}}">
             <i class="fas fa-sack"></i>
             <meter class="{{ifThen (gt current value) 'exceeds-max' '' }}" value="{{current}}" min="0"
               max="{{value}}"></meter>

--- a/src/templates/party.hbs
+++ b/src/templates/party.hbs
@@ -97,7 +97,7 @@
           <div class="party-meter party-meter--encumbrance" aria-label="{{localize 'ZWEI.actor.secondary.encumbranceLimit'}}"
             data-toolip="{{localize 'ZWEI.actor.secondary.encumbranceLimit'}}">
             <i class="fas fa-sack"></i>
-            <meter class="{{ifThen (gt current value) 'exceeds-max' '' }}" value="{{current}}" min="0"
+            <meter title="{{localize 'ZWEI.actor.secondary.encumbranceLimit'}}" class="{{ifThen (gt current value) 'exceeds-max' '' }}" value="{{current}}" min="0"
               max="{{value}}"></meter>
           </div>
           {{/with}}


### PR DESCRIPTION
The key encumbrance does not exist, the right one is: ZWEI.actor.secondary.encumbranceLimit
Also, the tooltip does not work with a meter tag - as a workaround i've added the title tag to the meter element, the problem is that the format of the title text is not the same of the tooltip, probably needs a css change, it is beyond my skills